### PR TITLE
VTK 9.3: class vtkUnicodeString has been dropped.

### DIFF
--- a/ParaViewScalarBar/vtkBoundingRectContextDevice2D.cxx
+++ b/ParaViewScalarBar/vtkBoundingRectContextDevice2D.cxx
@@ -7,7 +7,6 @@
 #include "vtkObjectFactory.h"
 #include "vtkPen.h"
 #include "vtkStdString.h"
-#include "vtkUnicodeString.h"
 
 //-----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkBoundingRectContextDevice2D)
@@ -74,23 +73,7 @@ vtkRectf vtkBoundingRectContextDevice2D::GetBoundingRect()
 //-----------------------------------------------------------------------------
 void vtkBoundingRectContextDevice2D::DrawString(float* point, const vtkStdString& string)
 {
-  this->DrawString(point, vtkUnicodeString::from_utf8(string));
-}
-
-//-----------------------------------------------------------------------------
-void vtkBoundingRectContextDevice2D::DrawString(float* point, const vtkUnicodeString& string)
-{
-  if (!this->DelegateDevice)
-  {
-    vtkWarningMacro(<< "No DelegateDevice defined");
-    return;
-  }
-
-  float bounds[4];
-  this->DelegateDevice->ComputeJustifiedStringBounds(string.utf8_str(), bounds);
-
-  this->AddPoint(point[0] + bounds[0], point[1] + bounds[1]);
-  this->AddPoint(point[0] + bounds[0] + bounds[2], point[1] + bounds[1] + bounds[3]);
+  this->DrawMathTextString(point, string);
 }
 
 //-----------------------------------------------------------------------------
@@ -400,16 +383,6 @@ void vtkBoundingRectContextDevice2D::DrawEllipticArc(
 //-----------------------------------------------------------------------------
 void vtkBoundingRectContextDevice2D::ComputeStringBounds(
   const vtkStdString& string, float bounds[4])
-{
-  if (this->DelegateDevice)
-  {
-    this->DelegateDevice->ComputeStringBounds(string, bounds);
-  }
-}
-
-//-----------------------------------------------------------------------------
-void vtkBoundingRectContextDevice2D::ComputeStringBounds(
-  const vtkUnicodeString& string, float bounds[4])
 {
   if (this->DelegateDevice)
   {

--- a/ParaViewScalarBar/vtkBoundingRectContextDevice2D.h
+++ b/ParaViewScalarBar/vtkBoundingRectContextDevice2D.h
@@ -91,11 +91,6 @@ public:
   /**
    * Expand bounding box to contain the string's bounding box.
    */
-  void DrawString(float* point, const vtkUnicodeString& string) override;
-
-  /**
-   * Expand bounding box to contain the string's bounding box.
-   */
   void DrawMathTextString(float* point, const vtkStdString& string) override;
 
   /**
@@ -254,11 +249,6 @@ public:
    * Forward string bounds calculation to the delegate device.
    */
   void ComputeStringBounds(const vtkStdString& string, float bounds[4]) override;
-
-  /**
-   * Forward string bounds calculation to the delegate device.
-   */
-  void ComputeStringBounds(const vtkUnicodeString& string, float bounds[4]) override;
 
   /**
    * Forward string bounds calculation to the delegate device.


### PR DESCRIPTION
This merge request baically contains removal/adaptation of code using the class `vtkUnicodeString` that has been dropped in VTK 9.3.